### PR TITLE
Added fix to hook

### DIFF
--- a/google_sso_django_nextjs_example/frontend/pages/index.js
+++ b/google_sso_django_nextjs_example/frontend/pages/index.js
@@ -15,7 +15,7 @@ export default function Home({ providers }) {
 
     }
 
-  }, [session])
+  }, [session?.auth_token])
   function backendapi(auth_token) {
     // var tag = document.getElementById("user_token").innerHTML = auth_token
     fetch(`http://127.0.0.1:8000/accounts/google/`, {


### PR DESCRIPTION
Previously the session object would get reinitialized twice while having the same auth_token value. This would causes two request in rapid succession, this would cause a race condition on the backend and occasionally throw an error.